### PR TITLE
fix: 主要修复了「水印空白渲染」的问题

### DIFF
--- a/document.js
+++ b/document.js
@@ -198,7 +198,8 @@ const data = {
 	config,
 	width:400,
 	userNamesText,
-	superMode:false
+	superMode:false,
+  convoluteNames
 };
 
 

--- a/patina.js
+++ b/patina.js
@@ -532,10 +532,11 @@ const patina = (imageEl, _config, app)=>{
                     )
                 }
                 
+                app.output = _src
+
                 if(i < _round){
                     one();
                 }else{
-                    app.output = _src
                     app.runing = false
                     app.current = 0
 
@@ -545,7 +546,6 @@ const patina = (imageEl, _config, app)=>{
                 }
             }
             _imgEl.src = _src
-            app.output = _src
         
     }
 


### PR DESCRIPTION
## 切换水印，空白渲染的问题

其实不是切换水印才会导致的。这个bug出现的条件是

1. 移动端（电脑端的 chrome / firefox 都不会，移动端的 chrome / firefox / safari 都会出现）
2. 输出结果的标签（ `<img :src="output" ... />` ）在视口外，同时在运行 `patina()` 函数。

切换水印只是恰好满足这两个条件。复现的例子：

<details>
<summary>展开GIF</summary>
<img alt="bug复现例子" width="200" src="https://user-images.githubusercontent.com/64010148/181029443-531a54fc-84a3-4f99-ae56-ecb9f578aba5.gif" />
</details><br>


我的解决方案是，对 `patina.js` 的 `one()` 作了修改，精简了修改 `app.output = _src` 的次数。因为我猜测，bug 一部分是 vue 多次渲染导致的。

> 真的就是猜测。
> 
> 1. 原本的代码中，在 `_imgEl.onload` 前后分别定义了一次 `app.output` 。我觉得 onload 之后是在调偏移位置。onload 前后分别定义一次，是为了让视觉更流畅。但是 `onload` 回调是异步的，他可能出锅。而且 vue 版本比较老，响应性上不清楚会出现什么奇怪的问题，还不报错。
> 2. 因为只有移动端出 bug，所以有没有可能，移动端为了节约资源，在不可见的 `img` 上埋了坑。
> 
> 水平有限，我感觉以上两点也不像是 bug 原因。。。期待讨论，我还蛮好奇的🤣

个人测试了移动端的 chrome / firefox / safari，好像没问题。

## 附注：「高级功能」选项有一个奇怪的地方

`convoluteNames` 没挂载，报错了，一整个 `v-for` 都没渲染

![[Vue warn]: Property or method "convoluteNames" is not defined on the instance](https://user-images.githubusercontent.com/64010148/181030196-9b6fb4b1-3059-4e18-87b6-b93314ba41e4.png)

我挂在了 `vm.data` 上。。。

不知道是不是故意不挂载的。如果是故意的，就把这个 commit 撤销好了。

## 附注2：桌面 firefox 的 range 条

桌面端 firefox 的那个拉杆，不知道为什么没有轨道。移动端没问题。less 样式没看出不当。如果不是我的个人问题，是否考虑加个补救措施？🤣

![ff的 range input](https://user-images.githubusercontent.com/64010148/181030673-7a24799e-8f95-424a-8e8d-cf861a3de4a2.png)
